### PR TITLE
Fixes bug in Angular 9 where the gauge cannot be initialized

### DIFF
--- a/projects/ngx-liquid-gauge/src/lib/ngx-liquid-gauge.component.ts
+++ b/projects/ngx-liquid-gauge/src/lib/ngx-liquid-gauge.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, AfterViewInit, ViewChild, Input, OnChanges, SimpleChanges } from '@angular/core';
 import * as d3 from 'd3';
 import * as liquid from './liquidFillGauge';
 
@@ -36,7 +36,7 @@ export class NgxLiquidGaugeComponent implements OnInit, OnChanges {
 
   constructor() { }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.createChart();
   }
 


### PR DESCRIPTION
See #16. Basically, when trying to use this library on Angular 9, the component fails to initialize with the ngOnInit function as it's being called too early. Thankfully, there's an ngAfterViewInit function which fixes the issue with no apparent side effects. This is backwards-compatible as well.

See [this SO post](https://stackoverflow.com/questions/45030943/angular2-cannot-read-property-nativeelement-of-undefined/47986327#47986327) for more details.

Let me know if you have any questions regarding this PR! It's been tested on my end as well.